### PR TITLE
Add support for custom Title Sorting

### DIFF
--- a/components/GamesList.qml
+++ b/components/GamesList.qml
@@ -38,7 +38,7 @@ Item {
     // Sort mode that the items have applied to them.
     // Is used to determine how to show the quick index.
     // Doesn't actually apply the sort to the collection.
-    property var sortMode: "title"
+    property var sortMode: "sort_title"
     property var sortDirection: 0
 
     property var selectSeeAll : {
@@ -133,7 +133,7 @@ Item {
             width: 30
             focus: showIndex
             active: showIndex
-            alpha: sortMode == "title" 
+            alpha: sortMode == "sort_title" 
             reversed: sortDirection == 1
             selectedItem: selectedGame
             selectedItemIndex: gameView.currentIndex

--- a/components/GamesList.qml
+++ b/components/GamesList.qml
@@ -38,7 +38,7 @@ Item {
     // Sort mode that the items have applied to them.
     // Is used to determine how to show the quick index.
     // Doesn't actually apply the sort to the collection.
-    property var sortMode: "sort_title"
+    property var sortMode: "sortBy"
     property var sortDirection: 0
 
     property var selectSeeAll : {
@@ -133,7 +133,7 @@ Item {
             width: 30
             focus: showIndex
             active: showIndex
-            alpha: sortMode == "sort_title" 
+            alpha: sortMode == "sortBy" 
             reversed: sortDirection == 1
             selectedItem: selectedGame
             selectedItemIndex: gameView.currentIndex

--- a/components/GamesPage.qml
+++ b/components/GamesPage.qml
@@ -23,7 +23,7 @@ Item {
     property var collectionSortTitle: {
         var title = "Title"
         switch (collectionSortMode) {
-            case "sort_title": {
+            case "sortBy": {
                 title = "By Title"
                 break
             }

--- a/components/GamesPage.qml
+++ b/components/GamesPage.qml
@@ -23,7 +23,7 @@ Item {
     property var collectionSortTitle: {
         var title = "Title"
         switch (collectionSortMode) {
-            case "title": {
+            case "sort_title": {
                 title = "By Title"
                 break
             }

--- a/components/SortItem.qml
+++ b/components/SortItem.qml
@@ -2,7 +2,7 @@ import QtQuick 2.12
 import QtGraphicalEffects 1.12
 Item {
     property var title: "Title"
-    property var mode: "sort_title"
+    property var mode: "sortBy"
     property var itemColor: "#00000"
     property var selected: {
         return collectionSortMode == mode
@@ -11,7 +11,7 @@ Item {
         return (collectionSortDirection == 0 ? "ascending" : "descending")
     }
     property var showSortOrder: {
-        return (collectionSortMode == "sort_title" || collectionSortMode == "release") 
+        return (collectionSortMode == "sortBy" || collectionSortMode == "release") 
     }
 
     property var activeSortImage : {

--- a/components/SortItem.qml
+++ b/components/SortItem.qml
@@ -2,7 +2,7 @@ import QtQuick 2.12
 import QtGraphicalEffects 1.12
 Item {
     property var title: "Title"
-    property var mode: "title"
+    property var mode: "sort_title"
     property var itemColor: "#00000"
     property var selected: {
         return collectionSortMode == mode
@@ -11,7 +11,7 @@ Item {
         return (collectionSortDirection == 0 ? "ascending" : "descending")
     }
     property var showSortOrder: {
-        return (collectionSortMode == "title" || collectionSortMode == "release") 
+        return (collectionSortMode == "sort_title" || collectionSortMode == "release") 
     }
 
     property var activeSortImage : {

--- a/components/SortModal.qml
+++ b/components/SortModal.qml
@@ -81,7 +81,7 @@ Item {
                 SortItem {
                     title: "By Title"
                     width: parent.width
-                    mode: "title"
+                    mode: "sort_title"
                     itemColor: sortColor
                     KeyNavigation.down: by_last_played
                 }

--- a/components/SortModal.qml
+++ b/components/SortModal.qml
@@ -81,7 +81,7 @@ Item {
                 SortItem {
                     title: "By Title"
                     width: parent.width
-                    mode: "sort_title"
+                    mode: "sortBy"
                     itemColor: sortColor
                     KeyNavigation.down: by_last_played
                 }

--- a/theme.qml
+++ b/theme.qml
@@ -24,7 +24,7 @@ FocusScope {
         currentCollectionIndex = api.memory.get('currentCollectionIndex') ?? 0
         currentPage = api.memory.get('currentPage') ?? 'HomePage'
         collectionListIndex = api.memory.get('collectionListIndex') ?? 0
-        collectionSortMode = api.memory.get('collectionSortMode') ?? "title"
+        collectionSortMode = api.memory.get('collectionSortMode') ?? "sort_title"
         collectionSortDirection =  api.memory.get('collectionSortDirection') ?? 0
         collectionFilterMode =  api.memory.get('collectionFilterMode') ?? "all"
         collectionShowAllItems =  api.memory.get('collectionShowAllItems') ?? false
@@ -66,7 +66,7 @@ FocusScope {
 
     // Collection sort mode
     // Collection list index
-    property var collectionSortMode : "title"
+    property var collectionSortMode : "sort_title"
     property var collectionSortDirection : 0
     property var collectionFilterMode : "all"
 
@@ -77,7 +77,7 @@ FocusScope {
         if (collectionSortMode != sortMode || sortMode == "lastPlayed" || sortMode == "rating")  { 
         
             switch (sortMode) {
-                case "title": {
+                case "sort_title": {
                     direction = 0
                     break
                 }

--- a/theme.qml
+++ b/theme.qml
@@ -24,7 +24,7 @@ FocusScope {
         currentCollectionIndex = api.memory.get('currentCollectionIndex') ?? 0
         currentPage = api.memory.get('currentPage') ?? 'HomePage'
         collectionListIndex = api.memory.get('collectionListIndex') ?? 0
-        collectionSortMode = api.memory.get('collectionSortMode') ?? "sort_title"
+        collectionSortMode = api.memory.get('collectionSortMode') ?? "sortBy"
         collectionSortDirection =  api.memory.get('collectionSortDirection') ?? 0
         collectionFilterMode =  api.memory.get('collectionFilterMode') ?? "all"
         collectionShowAllItems =  api.memory.get('collectionShowAllItems') ?? false
@@ -66,7 +66,7 @@ FocusScope {
 
     // Collection sort mode
     // Collection list index
-    property var collectionSortMode : "sort_title"
+    property var collectionSortMode : "sortBy"
     property var collectionSortDirection : 0
     property var collectionFilterMode : "all"
 
@@ -77,7 +77,7 @@ FocusScope {
         if (collectionSortMode != sortMode || sortMode == "lastPlayed" || sortMode == "rating")  { 
         
             switch (sortMode) {
-                case "sort_title": {
+                case "sortBy": {
                     direction = 0
                     break
                 }


### PR DESCRIPTION
Currently the games collection list ignores the `sort_title` key that allows you to add a custom override title to help with sort order. e.g Games with roman numerals tend to be in the wrong list order.

It also supports sort-by and sort_name as well.

Fixes #19